### PR TITLE
Change function name in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ search-and-replace, and testing each change over and over again. Dear beleaguere
     foo, 4, 2); /* params */
 
     api_exec(jack,
-    total_commitment_to_my_foo,  /* on success - foo is passed automatically to this function */
+    preemptive_strike,  /* on success - foo is passed automatically to this function */
     log_it, /* on error */
     foo, 3, 6); /* params */
 


### PR DESCRIPTION
NIT: Looking at line 59, it looks like the success case for calling jack() should be preemptive_strike, not total_commitment_to_my_foo.